### PR TITLE
chore: add OSS governance files

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,123 +1,46 @@
-# https://github.com/actions/labeler
-Apple Metal:
-    - changed-files:
-        - any-glob-to-any-file:
-            - ggml/include/ggml-metal.h
-            - ggml/src/ggml-metal/**
-            - README-metal.md
-SYCL:
-    - changed-files:
-        - any-glob-to-any-file:
-            - ggml/include/ggml-sycl.h
-            - ggml/src/ggml-sycl/**
-            - docs/backend/SYCL.md
-            - examples/sycl/**
-Nvidia GPU:
-    - changed-files:
-        - any-glob-to-any-file:
-            - ggml/include/ggml-cuda.h
-            - ggml/src/ggml-cuda/**
-Vulkan:
-    - changed-files:
-        - any-glob-to-any-file:
-            - ggml/include/ggml-vulkan.h
-            - ggml/src/ggml-vulkan/**
-IBM zDNN:
-    - changed-files:
-        - any-glob-to-any-file:
-            - ggml/include/ggml-zdnn.h
-            - ggml/src/ggml-zdnn/**
-documentation:
-    - changed-files:
-        - any-glob-to-any-file:
-            - docs/**
-            - media/**
-testing:
-    - changed-files:
-        - any-glob-to-any-file:
-            - tests/**
-build:
-    - changed-files:
-        - any-glob-to-any-file:
-            - cmake/**
-            - CMakeLists.txt
-            - CMakePresets.json
-examples:
-    - changed-files:
-        - any-glob-to-any-file:
-            - examples/**
-            - tools/**
-devops:
-    - changed-files:
-        - any-glob-to-any-file:
-            - .devops/**
-            - .github/**
-            - ci/**
-python:
-    - changed-files:
-        - any-glob-to-any-file:
-            - "**/*.py"
-            - requirements/**
-            - gguf-py/**
-            - .flake8
-script:
-    - changed-files:
-        - any-glob-to-any-file:
-            - scripts/**
-android:
-    - changed-files:
-        - any-glob-to-any-file:
-            - examples/llama.android/**
+# Auto-labeling rules for PRs based on changed files
+
+compaction:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'src/llama-kv-compact-*'
+      - 'src/llama-kv-cache.cpp'
+      - 'src/llama-kv-cache.h'
+
+solver:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'src/llama-kv-compact-solver*'
+      - 'src/llama-kv-compact-prefill*'
+
+metal:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'ggml/src/ggml-metal*'
+      - 'src/llama-kv-compact-solver-metal*'
+
 server:
-    - changed-files:
-        - any-glob-to-any-file:
-            - tools/server/**
-ggml:
-    - changed-files:
-        - any-glob-to-any-file:
-            - ggml/**
-model:
-    - changed-files:
-        - any-glob-to-any-file:
-            - src/models/**
-nix:
-    - changed-files:
-        - any-glob-to-any-file:
-            - "**/*.nix"
-            - .github/workflows/nix-*.yml
-            - .devops/nix/nixpkgs-instances.nix
-embedding:
-    - changed-files:
-        - any-glob-to-any-file: examples/embedding/
-jinja parser:
-    - changed-files:
-        - any-glob-to-any-file:
-            - common/jinja/**
-Ascend NPU:
-    - changed-files:
-        - any-glob-to-any-file:
-            - ggml/include/ggml-cann.h
-            - ggml/src/ggml-cann/**
-            - docs/backend/CANN.md
-OpenCL:
-    - changed-files:
-        - any-glob-to-any-file:
-            - ggml/include/ggml-opencl.h
-            - ggml/src/ggml-opencl/**
-            - docs/backend/OPENCL.md
-Hexagon:
-    - changed-files:
-        - any-glob-to-any-file:
-            - ggml/include/ggml-hexagon.h
-            - ggml/src/ggml-hexagon/**
-WebGPU:
-    - changed-files:
-        - any-glob-to-any-file:
-            - ggml/include/ggml-webgpu.h
-            - ggml/src/ggml-webgpu/**
-OpenVINO:
-    - changed-files:
-        - any-glob-to-any-file:
-            - ggml/include/ggml-openvino.h
-            - ggml/src/ggml-openvino/**
-            - docs/backend/OPENVINO.md
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'tools/server/**'
+
+tests:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'tests/**'
+
+ci:
+  - changed-files:
+    - any-glob-to-any-file:
+      - '.github/workflows/**'
+
+docs:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'docs/**'
+      - '*.md'
+
+upstream-sync:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'docs/UPSTREAM-SYNC.md'

--- a/.github/workflows/modelai-auto-label.yml
+++ b/.github/workflows/modelai-auto-label.yml
@@ -1,0 +1,18 @@
+name: modelai-auto-label
+
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          configuration-path: .github/labeler.yml
+          sync-labels: true

--- a/.github/workflows/modelai-stale.yml
+++ b/.github/workflows/modelai-stale.yml
@@ -1,0 +1,40 @@
+name: modelai-stale
+
+on:
+  schedule:
+    # Run every Saturday at 3 PM MT (9 PM UTC) — one hour after upstream watch
+    - cron: '0 21 * * 6'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          # Issues
+          stale-issue-message: >
+            This issue has been inactive for 60 days. It will be closed in 30 days
+            unless there is new activity. If this issue is still relevant, please
+            comment to keep it open.
+          close-issue-message: >
+            Closed due to 90 days of inactivity. Feel free to reopen if still relevant.
+          days-before-issue-stale: 60
+          days-before-issue-close: 30
+          stale-issue-label: 'stale'
+          exempt-issue-labels: 'keep-open,bug,security'
+
+          # Pull Requests
+          stale-pr-message: >
+            This PR has been inactive for 30 days. It will be closed in 14 days
+            unless updated. Please rebase and push if this work is still in progress.
+          close-pr-message: >
+            Closed due to 44 days of inactivity. Feel free to reopen with a fresh branch.
+          days-before-pr-stale: 30
+          days-before-pr-close: 14
+          stale-pr-label: 'stale'
+          exempt-pr-labels: 'keep-open,work-in-progress'

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,53 @@
+# Code of Conduct
+
+## Our Standard
+
+This project maintains a high bar for both code quality and community conduct. We expect all participants to act professionally, respectfully, and constructively.
+
+## Engineering Standards
+
+All contributions to this project must follow the quality process defined in [CONTRIBUTING.md](CONTRIBUTING.md):
+
+1. Document changes thoroughly
+2. Follow the adversarial review protocol ([AGENTS.md](AGENTS.md))
+3. Address all review findings before merge
+4. Test everything — no exceptions
+5. Commit to a feature branch with a descriptive message
+6. Merge to `modelai-main` only after review PASS and CI green
+
+These are not suggestions. Code that bypasses this process does not enter the repository.
+
+## Community Standards
+
+We adopt the [Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/) with the following enforcement guidelines:
+
+### Expected Behavior
+
+- Constructive, specific feedback in code reviews
+- Respect for different experience levels and perspectives
+- Focus on the technical merits of contributions
+- Graceful acceptance of constructive criticism
+
+### Unacceptable Behavior
+
+- Personal attacks, insults, or derogatory comments
+- Harassment in any form
+- Publishing others' private information without consent
+- Trolling or deliberately disruptive behavior
+
+### Enforcement
+
+| Level | Action | Consequence |
+|-------|--------|-------------|
+| 1. Correction | First offense, minor | Private warning, explanation of violation |
+| 2. Warning | Pattern of behavior | Temporary interaction restrictions |
+| 3. Temporary Ban | Serious violation | Removed from project for a defined period |
+| 4. Permanent Ban | Sustained pattern | Permanent removal from all project spaces |
+
+### Reporting
+
+Report conduct violations via [GitHub Issues](https://github.com/jandhyala-dev/modelai-llama.cpp/issues) or the private vulnerability reporting channel for sensitive matters.
+
+## Attribution
+
+Community standards are adapted from the [Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,97 +1,39 @@
 # Security Policy
 
- - [**Reporting a vulnerability**](#reporting-a-vulnerability)
- - [**Requirements**](#requirements)
- - [**Covered Topics**](#covered-topics)
- - [**Using llama.cpp securely**](#using-llamacpp-securely)
-   - [Untrusted models](#untrusted-models)
-   - [Untrusted inputs](#untrusted-inputs)
-   - [Data privacy](#data-privacy)
-   - [Untrusted environments or networks](#untrusted-environments-or-networks)
-   - [Multi-Tenant environments](#multi-tenant-environments)
+## Reporting a Vulnerability
 
-## Reporting a vulnerability
+If you discover a security vulnerability in modelai-llama.cpp, please report it responsibly.
 
-If you have discovered a security vulnerability in this project that falls inside the [covered topics](#covered-topics), please report it privately. **Do not disclose it as a public issue.** This gives us time to work with you to fix the issue before public exposure, reducing the chance that the exploit will be used before a patch is released.
+**Do NOT open a public issue.**
 
-Please disclose it as a private [security advisory](https://github.com/ggml-org/llama.cpp/security/advisories/new).
+Instead, use [GitHub's private vulnerability reporting](https://github.com/jandhyala-dev/modelai-llama.cpp/security/advisories/new) to submit your report. This ensures the vulnerability is handled privately until a fix is available.
 
-A team of volunteers on a reasonable-effort basis maintains this project. As such, please give us at least 90 days to work on a fix before public exposure.
+### What to Include
 
-> [!IMPORTANT]
-> For collaborators: if you are interested in helping out with reviewing private security disclosures, please see: https://github.com/ggml-org/llama.cpp/discussions/18080
+- Description of the vulnerability
+- Steps to reproduce
+- Affected versions or commits
+- Potential impact (crash, data corruption, remote code execution, etc.)
 
-## Requirements
+### Response Timeline
 
-Before submitting your report, ensure you meet the following requirements:
+- **Acknowledgment:** Within 48 hours
+- **Initial assessment:** Within 7 days
+- **Fix or mitigation:** Depends on severity, targeting 30 days for Critical/High
 
-- You have read this policy and fully understand it.
-- AI is only permitted in an assistive capacity as stated in [AGENTS.md](AGENTS.md). We do not accept reports that are written exclusively by AI.
-- Your report must include a working Proof-of-Concept in the form of a script and/or attached files.
+### Severity Levels
 
-Maintainers reserve the right to close the report if these requirements are not fulfilled.
+| Severity | CVSS | Examples |
+|----------|------|---------|
+| Critical | >= 9.0 | Remote code execution, full system compromise |
+| High | 7.0 - 8.9 | RCE in limited contexts, significant data loss |
+| Moderate | 4.0 - 6.9 | Denial of service, partial disruption |
+| Low | < 4.0 | Information disclosure, non-exploitable flaws |
 
-## Covered Topics
+### Track Record
 
-Only vulnerabilities that fall within these parts of the project are considered valid. For problems falling outside of this list, please report them as issues.
+- **RPC RCE patch (#20908):** Synced same-day from upstream llama.cpp and deployed immediately. See [UPSTREAM-SYNC.md](docs/UPSTREAM-SYNC.md) for details.
 
-- `src/**/*`
-- `ggml/**/*`
-- `gguf-py/**/*`
-- `tools/server/*`, **excluding** the following topics:
-    - Web UI
-    - Features marked as experimental
-    - Features not recommended for use in untrusted environments (e.g., router, MCP)
-    - Bugs that can lead to Denial-of-Service attack
+## Supported Versions
 
-Note that none of the topics under [Using llama.cpp securely](#using-llamacpp-securely) are considered vulnerabilities in LLaMA C++.
-
-For vulnerabilities that fall within the `vendor` directory, please report them directly to the third-party project.
-
-## Using llama.cpp securely
-
-### Untrusted models
-Be careful when running untrusted models. This classification includes models created by unknown developers or utilizing data obtained from unknown sources.
-
-*Always execute untrusted models within a secure, isolated environment such as a sandbox* (e.g., containers, virtual machines). This helps protect your system from potentially malicious code.
-
-> [!NOTE]
-> The trustworthiness of a model is not binary. You must always determine the proper level of caution depending on the specific model and how it matches your use case and risk tolerance.
-
-### Untrusted inputs
-
-Some models accept various input formats (text, images, audio, etc.). The libraries converting these inputs have varying security levels, so it's crucial to isolate the model and carefully pre-process inputs to mitigate script injection risks.
-
-For maximum security when handling untrusted inputs, you may need to employ the following:
-
-* Sandboxing: Isolate the environment where the inference happens.
-* Pre-analysis: Check how the model performs by default when exposed to prompt injection (e.g. using [fuzzing for prompt injection](https://github.com/FonduAI/awesome-prompt-injection?tab=readme-ov-file#tools)). This will give you leads on how hard you will have to work on the next topics.
-* Updates: Keep both LLaMA C++ and your libraries updated with the latest security patches.
-* Input Sanitation: Before feeding data to the model, sanitize inputs rigorously. This involves techniques such as:
-    * Validation: Enforce strict rules on allowed characters and data types.
-    * Filtering: Remove potentially malicious scripts or code fragments.
-    * Encoding: Convert special characters into safe representations.
-    * Verification: Run tooling that identifies potential script injections (e.g. [models that detect prompt injection attempts](https://python.langchain.com/docs/guides/safety/hugging_face_prompt_injection)).
-
-### Data privacy
-
-To protect sensitive data from potential leaks or unauthorized access, it is crucial to sandbox the model execution. This means running the model in a secure, isolated environment, which helps mitigate many attack vectors.
-
-### Untrusted environments or networks
-
-If you can't run your models in a secure and isolated environment or if it must be exposed to an untrusted network, make sure to take the following security precautions:
-* Do not use the RPC backend, [rpc-server](https://github.com/ggml-org/llama.cpp/tree/master/tools/rpc) and [llama-server](https://github.com/ggml-org/llama.cpp/tree/master/tools/server) functionality (see https://github.com/ggml-org/llama.cpp/pull/13061).
-* Confirm the hash of any downloaded artifact (e.g. pre-trained model weights) matches a known-good value.
-* Encrypt your data if sending it over the network.
-
-### Multi-Tenant environments
-
-If you intend to run multiple models in parallel with shared memory, it is your responsibility to ensure the models do not interact or access each other's data. The primary areas of concern are tenant isolation, resource allocation, model sharing and hardware attacks.
-
-1. Tenant Isolation: Models should run separately with strong isolation methods to prevent unwanted data access. Separating networks is crucial for isolation, as it prevents unauthorized access to data or models and malicious users from sending graphs to execute under another tenant's identity.
-
-2. Resource Allocation: A denial of service caused by one model can impact the overall system health. Implement safeguards like rate limits, access controls, and health monitoring.
-
-3. Model Sharing: In a multitenant model sharing design, tenants and users must understand the security risks of running code provided by others. Since there are no reliable methods to detect malicious models, sandboxing the model execution is the recommended approach to mitigate the risk.
-
-4. Hardware Attacks: GPUs or TPUs can also be attacked. [Researches](https://scholar.google.com/scholar?q=gpu+side+channel) has shown that side channel attacks on GPUs are possible, which can make data leak from other models or processes running on the same system at the same time.
+Only the latest release on `modelai-main` is supported with security updates.


### PR DESCRIPTION
## Summary
- **SECURITY.md** — vulnerability reporting policy with CVSS severity levels and response timeline
- **CODE_OF_CONDUCT.md** — engineering quality standards + Contributor Covenant v2.1 with 4 enforcement levels
- **modelai-stale.yml** — auto-close inactive issues (90 days) and PRs (44 days), runs Saturdays 3 PM MT
- **modelai-auto-label.yml + labeler.yml** — auto-label PRs by area (compaction, solver, metal, server, tests, ci, docs, upstream-sync)

## Test plan
- [ ] Verify SECURITY.md renders correctly on GitHub (Settings → Code security → Security policy)
- [ ] Verify CODE_OF_CONDUCT.md linked from GitHub community profile
- [ ] Manual trigger stale workflow: Actions → modelai-stale → Run workflow
- [ ] Open a test PR touching `src/llama-kv-compact-*` to verify auto-label applies `compaction`